### PR TITLE
Optimized  payload staging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "databeam"
-version = "0.2.2"
+version = "0.2.5"
 dependencies = [
  "dirs",
  "eframe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "databeam"
-version = "0.2.2"
+version = "0.2.5"
 edition = "2021"
 description = "A beautiful GUI wrapper for croc and sendme file transfer tools"
 authors = ["DataBeam <databeam@users.noreply.github.com>"]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -13,7 +13,6 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use flate2::read::GzDecoder;
-use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use sendme_native::{
     check_and_export_local_in as native_check_and_export_local_in,
     cleanup_sendme_receive_artifacts_for_ticket_in as native_cleanup_sendme_receive_artifacts_for_ticket_in,
@@ -601,6 +600,39 @@ fn sender_blob_base_dir(base_dir: Option<&Path>) -> Option<PathBuf> {
     base_dir.map(|dir| dir.join("databeam_sender_stuff"))
 }
 
+fn derive_payload_root_name(paths: &[PathBuf]) -> Result<String, String> {
+    if paths.is_empty() {
+        return Err("No paths provided".to_string());
+    }
+
+    let mut largest_item = &paths[0];
+    let mut largest_size = 0u64;
+
+    for p in paths {
+        let size = if p.is_dir() {
+            get_dir_size(p)
+        } else {
+            fs::metadata(p).map(|m| m.len()).unwrap_or(0)
+        };
+        if size > largest_size {
+            largest_size = size;
+            largest_item = p;
+        }
+    }
+
+    let base_name = largest_item
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("files");
+
+    let mut name_slug: String = base_name.chars().take(20).collect();
+    if paths.len() > 1 {
+        name_slug.push_str("_and_more");
+    }
+    name_slug.push_str("_databeam");
+    Ok(name_slug)
+}
+
 #[derive(Debug, Clone, Deserialize)]
 struct NativeSenderRequestStarted {
     endpoint_id: String,
@@ -888,64 +920,6 @@ fn read_lines_cr_aware(
     }
 }
 
-#[allow(dead_code)]
-fn run_sendme_with_pty(
-    binary: &str,
-    args: &[String],
-    runtime_dir: &Path,
-    current_dir: Option<&Path>,
-    tx: &mpsc::Sender<TransferMsg>,
-    cancel: Arc<AtomicBool>,
-    pid_handle: Arc<std::sync::Mutex<Option<u32>>>,
-    parser: fn(&str, &mpsc::Sender<TransferMsg>, &Arc<AtomicBool>),
-) -> Result<(bool, String), String> {
-    let pty_system = native_pty_system();
-    let pair = pty_system
-        .openpty(PtySize {
-            rows: 40,
-            cols: 120,
-            pixel_width: 0,
-            pixel_height: 0,
-        })
-        .map_err(|e| format!("Failed to create PTY: {e}"))?;
-
-    let mut cmd = CommandBuilder::new(binary);
-    cmd.env("RUST_LOG", "info");
-    cmd.env("IROH_DATA_DIR", runtime_dir.to_string_lossy().to_string());
-    for arg in args {
-        cmd.arg(arg);
-    }
-    if let Some(dir) = current_dir {
-        cmd.cwd(dir.to_string_lossy().to_string());
-    }
-
-    let mut child = pair
-        .slave
-        .spawn_command(cmd)
-        .map_err(|e| format!("Failed to start sendme in PTY: {e}"))?;
-
-    if let Ok(mut guard) = pid_handle.lock() {
-        *guard = child.process_id();
-    }
-
-    let reader = pair
-        .master
-        .try_clone_reader()
-        .map_err(|e| format!("Failed to attach PTY reader: {e}"))?;
-    let tx_reader = tx.clone();
-    let cancel_reader = cancel.clone();
-    let reader_thread = thread::spawn(move || {
-        read_lines_cr_aware(reader, tx_reader, parser, cancel_reader);
-    });
-
-    let status = child
-        .wait()
-        .map_err(|e| format!("Process wait failed: {e}"))?;
-    let _ = reader_thread.join();
-
-    Ok((status.success(), format!("{status:?}")))
-}
-
 // ── Croc Send ──────────────────────────────────────────────────────
 
 pub fn croc_send(
@@ -969,22 +943,15 @@ pub fn croc_send(
         if let Some(code) = &opts.custom_code {
             cmd.env("CROC_SECRET", code);
         }
-        let mut _staging_holder: Option<PathBuf> = None;
         if opts.text_mode {
             cmd.arg("--text");
             if let Some(text) = &opts.text_value {
                 cmd.arg(text);
             }
         } else {
-            let send_path = match create_staging_dir(&opts.paths, None) {
-                Ok(path) => path,
-                Err(e) => {
-                    let _ = tx.send(TransferMsg::Error(format!("Failed to stage files: {}", e)));
-                    return;
-                }
-            };
-            cmd.arg(&send_path);
-            // No _staging_holder needed as we use deterministic directories in Temp
+            for path in &opts.paths {
+                cmd.arg(path);
+            }
         }
 
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
@@ -1157,14 +1124,15 @@ pub fn sendme_send(
 
     let _worker = thread::spawn(move || {
         let sender_blob_dir = sender_blob_base_dir(opts.blob_dir.as_deref());
-        let (send_path, _staging_dir_path) =
-            match create_staging_dir(&opts.paths, sender_blob_dir.as_deref()) {
-            Ok(path) => (path, None::<PathBuf>), // We keep path, but we don't have a TempDir object anymore as it's deterministic
+        let payload_root_name = match derive_payload_root_name(&opts.paths) {
+            Ok(name) => name,
             Err(e) => {
-                let _ = tx.send(TransferMsg::Error(format!("Failed to stage files: {}", e)));
+                let _ = tx.send(TransferMsg::Error(format!("Failed to prepare payload: {}", e)));
                 return;
             }
         };
+
+        let paths = opts.paths.clone();
 
         let _ = tx.send(TransferMsg::Started);
 
@@ -1185,7 +1153,8 @@ pub fn sendme_send(
         let (evt_tx, evt_rx) = mpsc::channel::<NativeSendmeEvent>();
         let app_handle: NativeSendmeAppHandle = Some(Arc::new(NativeSendmeEmitter::new(evt_tx)));
         let share = runtime.block_on(native_sendme_start_share(
-            send_path.clone(),
+            paths,
+            payload_root_name,
             NativeSendOptions {
                 relay_mode: NativeRelayModeOption::Default,
                 ticket_type: NativeAddrInfoOptions::RelayAndAddresses,
@@ -1483,7 +1452,6 @@ pub fn sendme_send(
         }
 
         let _ = fs::remove_dir_all(&share.blobs_data_dir);
-        let _ = fs::remove_dir_all(&send_path); // Clean up the deterministic staging folder too
         if let Some(blob_base) = sender_blob_dir.as_ref() {
             cleanup_sendme_send_dirs(blob_base);
             cleanup_sendme_temp_artifacts(blob_base);
@@ -1495,78 +1463,6 @@ pub fn sendme_send(
     (rx, ProcessHandle { cancel, child_pid })
 }
 /// Create a deterministic staging directory with all items copied/linked into it for sendme
-fn create_staging_dir(paths: &[PathBuf], base_dir: Option<&Path>) -> Result<PathBuf, String> {
-    if paths.is_empty() {
-        return Err("No paths provided".to_string());
-    }
-
-    // 1. Find the largest item to serve as the name base
-    let mut largest_item = &paths[0];
-    let mut largest_size = 0u64;
-
-    for p in paths {
-        let size = if p.is_dir() {
-            get_dir_size(p)
-        } else {
-            fs::metadata(p).map(|m| m.len()).unwrap_or(0)
-        };
-        if size > largest_size {
-            largest_size = size;
-            largest_item = p;
-        }
-    }
-
-    // 2. Construct deterministic name
-    let base_name = largest_item
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("files");
-    
-    // Cap name to 20 chars
-    let mut name_slug: String = base_name.chars().take(20).collect();
-    if paths.len() > 1 {
-        name_slug.push_str("_and_more");
-    }
-    name_slug.push_str("_databeam");
-
-    // 3. Create the staging directory in Temp (not auto-deleted by TempDir object, but manual)
-    let temp_base = base_dir
-        .map(Path::to_path_buf)
-        .unwrap_or_else(std::env::temp_dir);
-    fs::create_dir_all(&temp_base).map_err(|e| format!("Could not create staging base dir: {}", e))?;
-    let staging_path = temp_base.join(&name_slug);
-    
-    // Clear any previous STALE staging attempt for this specific payload
-    // Note: We don't remove it if we want to skip linking, but linking is cheap,
-    // so clearing ensures we don't have old files from a modified payload.
-    let _ = fs::remove_dir_all(&staging_path);
-    fs::create_dir_all(&staging_path).map_err(|e| format!("Could not create staging dir: {}", e))?;
-
-    for src in paths {
-        // Prevent recursion
-        if staging_path.starts_with(src) {
-             continue;
-        }
-
-        let name = src
-            .file_name()
-            .ok_or_else(|| format!("Invalid path: {}", src.display()))?;
-        let dest = staging_path.join(name);
-
-        if src.is_dir() {
-            copy_dir_recursive(src, &dest)
-                .map_err(|e| format!("Failed to copy {}: {}", src.display(), e))?;
-        } else {
-            // Try hard link first, fallback to copy
-            if fs::hard_link(src, &dest).is_err() {
-                fs::copy(src, &dest).map_err(|e| format!("Failed to copy {}: {}", src.display(), e))?;
-            }
-        }
-    }
-
-    Ok(staging_path)
-}
-
 fn get_dir_size(path: &Path) -> u64 {
     let mut total = 0;
     if let Ok(entries) = fs::read_dir(path) {
@@ -1580,26 +1476,6 @@ fn get_dir_size(path: &Path) -> u64 {
         }
     }
     total
-}
-
-fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
-    fs::create_dir_all(dst)?;
-    for entry in fs::read_dir(src)? {
-        let entry = entry?;
-        let src_path = entry.path();
-        let dst_path = dst.join(entry.file_name());
-        if src_path.is_dir() {
-            copy_dir_recursive(&src_path, &dst_path)?;
-        } else if fs::hard_link(&src_path, &dst_path).is_err() {
-            fs::copy(&src_path, &dst_path)?;
-        }
-    }
-    Ok(())
-}
-
-#[allow(dead_code)]
-fn cleanup_runtime_dir(path: &Path) {
-    let _ = fs::remove_dir_all(path);
 }
 
 fn cleanup_sendme_send_dirs(base_dir: &Path) {
@@ -1643,29 +1519,6 @@ fn cleanup_sendme_temp_artifacts(temp_base: &Path) {
         }
     }
     let _ = fs::remove_dir(temp_base);
-}
-
-#[allow(dead_code)]
-fn cleanup_sendme_receive_artifacts(base_dir: &Path) {
-    let Ok(entries) = fs::read_dir(base_dir) else {
-        return;
-    };
-
-    for entry in entries.flatten() {
-        let path = entry.path();
-        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
-            continue;
-        };
-        if !name.starts_with(".sendme") {
-            continue;
-        }
-
-        if path.is_dir() {
-            let _ = fs::remove_dir_all(path);
-        } else {
-            let _ = fs::remove_file(path);
-        }
-    }
 }
 
 // ── Sendme Receive ─────────────────────────────────────────────────
@@ -1998,118 +1851,6 @@ fn extract_croc_code(trimmed: &str) -> Option<String> {
     None
 }
 
-#[allow(dead_code)]
-fn parse_sendme_common(line: &str, tx: &mpsc::Sender<TransferMsg>) -> Option<(String, String)> {
-    // Strip ANSI escape sequences (from pty/script wrapper)
-    let cleaned = strip_ansi(line);
-    let trimmed = cleaned.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-
-    // Ignore crossterm panic messages and internal noise
-    let lower = trimmed.to_lowercase();
-    if lower.contains("reader source not set")
-        || lower.contains("crossterm")
-        || lower.contains("rust_backtrace")
-        || lower.contains("panicked at")
-        || lower.contains("press c to copy")
-        || lower.contains("abort trap")
-    {
-        return None; // Don't show these as output or errors
-    }
-
-    // Detect ticket/code — sendme prints "sendme receive blob<ticket>"
-    if trimmed.contains("sendme receive ") {
-        if let Some(ticket_part) = trimmed.split("sendme receive ").last() {
-            let ticket = ticket_part.trim().to_string();
-            if !ticket.is_empty() {
-                let _ = tx.send(TransferMsg::Code(ticket));
-            }
-        }
-    } else if (trimmed.starts_with("blob") || trimmed.starts_with("Blob")) && trimmed.len() > 40 {
-        // Raw blob ticket on its own line
-        let _ = tx.send(TransferMsg::Code(trimmed.to_string()));
-    }
-
-    let _ = tx.send(TransferMsg::Output(trimmed.to_string()));
-    Some((trimmed.to_string(), lower))
-}
-
-#[allow(dead_code)]
-fn parse_sendme_send_output(line: &str, tx: &mpsc::Sender<TransferMsg>, _cancel: &Arc<AtomicBool>) {
-    let Some((trimmed, lower)) = parse_sendme_common(line, tx) else {
-        return;
-    };
-    if sendme_waiting_banner(&lower) {
-        let _ = tx.send(TransferMsg::WaitingForReceiver);
-    }
-
-    if sendme_sender_activity_line(&trimmed, &lower) {
-        let _ = tx.send(TransferMsg::SenderTransferActivity);
-    }
-
-    // Sender one-shot completion should be signaled by explicit send-finished lines.
-    if lower.contains("finished sending")
-        || lower.contains("transfer complete")
-        || lower.contains("peer disconnected")
-        || lower.contains("client disconnected")
-    {
-        let _ = tx.send(TransferMsg::Progress(1.0));
-        let _ = tx.send(TransferMsg::PeerDisconnected);
-    }
-}
-
-#[allow(dead_code)]
-fn parse_sendme_receive_output(line: &str, tx: &mpsc::Sender<TransferMsg>, _cancel: &Arc<AtomicBool>) {
-    let cleaned = strip_ansi(line);
-    let trimmed = cleaned.trim();
-    if trimmed.is_empty() {
-        return;
-    }
-
-    let Some((_trimmed, lower)) = parse_sendme_common(trimmed, tx) else {
-        return;
-    };
-
-    if lower.starts_with("error:") {
-        let _ = tx.send(TransferMsg::Error(trimmed.to_string()));
-        return;
-    }
-    // Some sendme builds keep the process alive briefly after this final summary line.
-    // Emit completion immediately so UI can transition out of downloading state.
-    if lower.contains("downloaded") && lower.contains("files") {
-        let _ = tx.send(TransferMsg::Progress(1.0));
-        let _ = tx.send(TransferMsg::Completed);
-    }
-}
-
-#[allow(dead_code)]
-fn sendme_waiting_banner(lower: &str) -> bool {
-    lower.contains("waiting for incoming transfer")
-        || lower.contains("waiting for incoming")
-        || lower.contains("waiting for receiver")
-}
-
-#[allow(dead_code)]
-fn sendme_sender_activity_line(trimmed: &str, lower: &str) -> bool {
-    if (lower.contains("[3/4]") || lower.contains("[4/4]"))
-        && (lower.contains("uploading") || lower.contains("downloading"))
-    {
-        return true;
-    }
-    if lower.contains("uploading ...") || lower.contains("downloading ...") {
-        return true;
-    }
-    let tokens: Vec<&str> = trimmed.split_whitespace().collect();
-    for pair in tokens.windows(2) {
-        if pair[0] == "r" && pair[1].contains('/') {
-            return true;
-        }
-    }
-    false
-}
-
 /// Strip ANSI escape sequences from a string
 fn strip_ansi(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
@@ -2169,13 +1910,8 @@ impl ProcessHandle {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        cleanup_sendme_send_dirs, parse_sendme_receive_output, parse_sendme_send_output,
-        TransferMsg,
-    };
+    use super::cleanup_sendme_send_dirs;
     use std::fs;
-    use std::sync::atomic::AtomicBool;
-    use std::sync::{mpsc, Arc};
 
     #[test]
     fn cleanup_removes_only_sendme_send_dirs() {
@@ -2198,169 +1934,5 @@ mod tests {
         assert!(!sendme_b.exists());
         assert!(keep_dir.exists());
         assert!(keep_file.exists());
-    }
-
-    #[test]
-    fn sendme_send_parser_marks_finished_sending_as_disconnected() {
-        let (tx, rx) = mpsc::channel();
-        let cancel = Arc::new(AtomicBool::new(false));
-        parse_sendme_send_output("finished sending to client", &tx, &cancel);
-
-        let mut saw_disconnect = false;
-        for _ in 0..4 {
-            match rx.try_recv() {
-                Ok(TransferMsg::PeerDisconnected) => {
-                    saw_disconnect = true;
-                    break;
-                }
-                Ok(_) => {}
-                Err(_) => break,
-            }
-        }
-
-        assert!(
-            saw_disconnect,
-            "expected parser to emit PeerDisconnected for finished sending"
-        );
-    }
-
-    #[test]
-    fn sendme_send_parser_marks_client_disconnected_as_disconnected() {
-        let (tx, rx) = mpsc::channel();
-        let cancel = Arc::new(AtomicBool::new(false));
-        parse_sendme_send_output("client disconnected", &tx, &cancel);
-
-        let mut saw_disconnect = false;
-        for _ in 0..4 {
-            match rx.try_recv() {
-                Ok(TransferMsg::PeerDisconnected) => {
-                    saw_disconnect = true;
-                    break;
-                }
-                Ok(_) => {}
-                Err(_) => break,
-            }
-        }
-
-        assert!(
-            saw_disconnect,
-            "expected PeerDisconnected for client disconnected line"
-        );
-    }
-
-    #[test]
-    fn sendme_send_parser_emits_waiting_for_receiver_signal() {
-        let (tx, rx) = mpsc::channel();
-        let cancel = Arc::new(AtomicBool::new(false));
-        parse_sendme_send_output("waiting for incoming transfer", &tx, &cancel);
-
-        let mut saw_waiting = false;
-        for _ in 0..6 {
-            match rx.try_recv() {
-                Ok(TransferMsg::WaitingForReceiver) => {
-                    saw_waiting = true;
-                    break;
-                }
-                Ok(_) => {}
-                Err(_) => break,
-            }
-        }
-
-        assert!(
-            saw_waiting,
-            "expected parser to emit WaitingForReceiver for waiting banner"
-        );
-    }
-
-    #[test]
-    fn sendme_send_parser_emits_sender_transfer_activity() {
-        let (tx, rx) = mpsc::channel();
-        let cancel = Arc::new(AtomicBool::new(false));
-        parse_sendme_send_output(
-            "[3/4] Uploading ... [00:03] [###>---] 300.00 MiB/600.00 MiB 10.00 MiB/s",
-            &tx,
-            &cancel,
-        );
-
-        let mut saw_activity = false;
-        for _ in 0..6 {
-            match rx.try_recv() {
-                Ok(TransferMsg::SenderTransferActivity) => {
-                    saw_activity = true;
-                    break;
-                }
-                Ok(_) => {}
-                Err(_) => break,
-            }
-        }
-
-        assert!(
-            saw_activity,
-            "expected parser to emit SenderTransferActivity for upload progress line"
-        );
-    }
-
-    #[test]
-    fn sendme_receive_parser_emits_high_frequency_noise_lines() {
-        let (tx, rx) = mpsc::channel();
-        let cancel = Arc::new(AtomicBool::new(false));
-        parse_sendme_receive_output(
-            "n 99549f9de3 r 31724666896/0 i 474 # f9ffee9093 [] 8 B/8 B",
-            &tx,
-            &cancel,
-        );
-
-        match rx.try_recv() {
-            Ok(TransferMsg::Output(_)) => {}
-            other => panic!("expected output message, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn sendme_receive_parser_marks_downloaded_files_as_completed() {
-        let (tx, rx) = mpsc::channel();
-        let cancel = Arc::new(AtomicBool::new(false));
-        parse_sendme_receive_output("downloaded 7 files, 595.45 MiB. took 5 seconds", &tx, &cancel);
-
-        let mut saw_completed = false;
-        for _ in 0..6 {
-            match rx.try_recv() {
-                Ok(TransferMsg::Completed) => {
-                    saw_completed = true;
-                    break;
-                }
-                Ok(_) => {}
-                Err(_) => break,
-            }
-        }
-
-        assert!(
-            saw_completed,
-            "expected receive parser to emit Completed for downloaded files line"
-        );
-    }
-
-    #[test]
-    fn sendme_receive_parser_emits_error_message_for_error_prefix_line() {
-        let (tx, rx) = mpsc::channel();
-        let cancel = Arc::new(AtomicBool::new(false));
-        parse_sendme_receive_output("error: ticket not found", &tx, &cancel);
-
-        let mut saw_error = false;
-        for _ in 0..6 {
-            match rx.try_recv() {
-                Ok(TransferMsg::Error(msg)) => {
-                    saw_error = msg.to_lowercase().starts_with("error:");
-                    break;
-                }
-                Ok(_) => {}
-                Err(_) => break,
-            }
-        }
-
-        assert!(
-            saw_error,
-            "expected receive parser to emit Error for error: line"
-        );
     }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -16,8 +16,10 @@ use flate2::read::GzDecoder;
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use sendme_native::{
     check_and_export_local_in as native_check_and_export_local_in,
+    cleanup_sendme_receive_artifacts_for_ticket_in as native_cleanup_sendme_receive_artifacts_for_ticket_in,
     download as native_sendme_download,
     local_ticket_size_on_disk as native_local_ticket_size_on_disk,
+    local_ticket_size_on_disk_in as native_local_ticket_size_on_disk_in,
     start_share as native_sendme_start_share,
     cleanup_sendme_receive_artifacts_for_ticket as native_cleanup_sendme_receive_artifacts_for_ticket,
     AddrInfoOptions as NativeAddrInfoOptions, AppHandle as NativeSendmeAppHandle,
@@ -584,13 +586,19 @@ pub struct CrocReceiveOptions {
 pub struct SendmeSendOptions {
     pub paths: Vec<PathBuf>,
     pub one_shot: bool,
+    pub blob_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone)]
 pub struct SendmeReceiveOptions {
     pub ticket: String,
     pub output_dir: Option<PathBuf>,
+    pub blob_dir: Option<PathBuf>,
     pub overwrite: bool,
+}
+
+fn sender_blob_base_dir(base_dir: Option<&Path>) -> Option<PathBuf> {
+    base_dir.map(|dir| dir.join("databeam_sender_stuff"))
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -968,7 +976,7 @@ pub fn croc_send(
                 cmd.arg(text);
             }
         } else {
-            let send_path = match create_staging_dir(&opts.paths) {
+            let send_path = match create_staging_dir(&opts.paths, None) {
                 Ok(path) => path,
                 Err(e) => {
                     let _ = tx.send(TransferMsg::Error(format!("Failed to stage files: {}", e)));
@@ -1148,7 +1156,9 @@ pub fn sendme_send(
     let child_pid = Arc::new(std::sync::Mutex::new(None));
 
     let _worker = thread::spawn(move || {
-        let (send_path, _staging_dir_path) = match create_staging_dir(&opts.paths) {
+        let sender_blob_dir = sender_blob_base_dir(opts.blob_dir.as_deref());
+        let (send_path, _staging_dir_path) =
+            match create_staging_dir(&opts.paths, sender_blob_dir.as_deref()) {
             Ok(path) => (path, None::<PathBuf>), // We keep path, but we don't have a TempDir object anymore as it's deterministic
             Err(e) => {
                 let _ = tx.send(TransferMsg::Error(format!("Failed to stage files: {}", e)));
@@ -1181,6 +1191,7 @@ pub fn sendme_send(
                 ticket_type: NativeAddrInfoOptions::RelayAndAddresses,
                 magic_ipv4_addr: None,
                 magic_ipv6_addr: None,
+                blob_dir: sender_blob_dir.clone(),
             },
             app_handle,
         ));
@@ -1473,14 +1484,18 @@ pub fn sendme_send(
 
         let _ = fs::remove_dir_all(&share.blobs_data_dir);
         let _ = fs::remove_dir_all(&send_path); // Clean up the deterministic staging folder too
-        cleanup_sendme_send_dirs(&std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
-        cleanup_sendme_temp_artifacts();
+        if let Some(blob_base) = sender_blob_dir.as_ref() {
+            cleanup_sendme_send_dirs(blob_base);
+            cleanup_sendme_temp_artifacts(blob_base);
+        }
+        cleanup_sendme_send_dirs(&std::env::temp_dir());
+        cleanup_sendme_temp_artifacts(&std::env::temp_dir());
     });
 
     (rx, ProcessHandle { cancel, child_pid })
 }
 /// Create a deterministic staging directory with all items copied/linked into it for sendme
-fn create_staging_dir(paths: &[PathBuf]) -> Result<PathBuf, String> {
+fn create_staging_dir(paths: &[PathBuf], base_dir: Option<&Path>) -> Result<PathBuf, String> {
     if paths.is_empty() {
         return Err("No paths provided".to_string());
     }
@@ -1515,7 +1530,10 @@ fn create_staging_dir(paths: &[PathBuf]) -> Result<PathBuf, String> {
     name_slug.push_str("_databeam");
 
     // 3. Create the staging directory in Temp (not auto-deleted by TempDir object, but manual)
-    let temp_base = std::env::temp_dir();
+    let temp_base = base_dir
+        .map(Path::to_path_buf)
+        .unwrap_or_else(std::env::temp_dir);
+    fs::create_dir_all(&temp_base).map_err(|e| format!("Could not create staging base dir: {}", e))?;
     let staging_path = temp_base.join(&name_slug);
     
     // Clear any previous STALE staging attempt for this specific payload
@@ -1603,8 +1621,7 @@ fn cleanup_sendme_send_dirs(base_dir: &Path) {
     }
 }
 
-fn cleanup_sendme_temp_artifacts() {
-    let temp_base = std::env::temp_dir();
+fn cleanup_sendme_temp_artifacts(temp_base: &Path) {
     let Ok(entries) = fs::read_dir(&temp_base) else {
         return;
     };
@@ -1625,6 +1642,7 @@ fn cleanup_sendme_temp_artifacts() {
             let _ = fs::remove_file(path);
         }
     }
+    let _ = fs::remove_dir(temp_base);
 }
 
 #[allow(dead_code)]
@@ -1687,7 +1705,7 @@ pub fn sendme_receive(
                 relay_mode: NativeRelayModeOption::Default,
                 magic_ipv4_addr: None,
                 magic_ipv6_addr: None,
-                blob_dir: None,
+                blob_dir: opts.blob_dir.clone(),
                 overwrite: opts.overwrite,
             },
             app_handle,
@@ -1824,10 +1842,19 @@ pub fn sendme_check_local(
 
         let ticket = opts.ticket.clone();
         let output_dir = opts.output_dir.clone();
+        let blob_dir = opts.blob_dir.clone();
         let overwrite = opts.overwrite;
         let (abort_tx, abort_rx) = tokio::sync::oneshot::channel::<()>();
         let task = runtime.spawn(async move {
-            native_check_and_export_local_in(&ticket, output_dir, app_handle, None, overwrite, Some(abort_rx)).await
+            native_check_and_export_local_in(
+                &ticket,
+                output_dir,
+                app_handle,
+                blob_dir,
+                overwrite,
+                Some(abort_rx),
+            )
+            .await
         });
 
         // Forward events to the transfer channel while task runs
@@ -1897,12 +1924,21 @@ pub fn sendme_check_local(
 
 
 
-pub fn cleanup_sendme_receive_artifacts_for_ticket(ticket_str: &str) {
-    native_cleanup_sendme_receive_artifacts_for_ticket(ticket_str)
+pub fn cleanup_sendme_receive_artifacts_for_ticket(ticket_str: &str, blob_dir: Option<&Path>) {
+    match blob_dir {
+        Some(path) => native_cleanup_sendme_receive_artifacts_for_ticket_in(
+            ticket_str,
+            Some(path.to_path_buf()),
+        ),
+        None => native_cleanup_sendme_receive_artifacts_for_ticket(ticket_str),
+    }
 }
 
-pub fn get_sendme_blob_directory_size(ticket_str: &str) -> u64 {
-    native_local_ticket_size_on_disk(ticket_str)
+pub fn get_sendme_blob_directory_size(ticket_str: &str, blob_dir: Option<&Path>) -> u64 {
+    match blob_dir {
+        Some(path) => native_local_ticket_size_on_disk_in(ticket_str, Some(path.to_path_buf())),
+        None => native_local_ticket_size_on_disk(ticket_str),
+    }
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,7 @@ enum PickerRequest {
     SendFolder,
     SendFiles,
     ReceiveFolder,
+    SendmeBlobFolder,
 }
 
 #[derive(Debug)]
@@ -66,6 +67,7 @@ enum PickerResult {
     SendFolder(Option<PathBuf>),
     SendFiles(Option<Vec<PathBuf>>),
     ReceiveFolder(Option<PathBuf>),
+    SendmeBlobFolder(Option<PathBuf>),
 }
 
 /// A file/folder entry with its cached size
@@ -91,6 +93,15 @@ struct EazyCacheEntry {
     timestamp: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+enum SendmeBlobDirMode {
+    #[default]
+    SystemTemp,
+    DownloadDir,
+    Custom,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct UserSettings {
     #[serde(default)]
@@ -101,6 +112,10 @@ struct UserSettings {
     croc_receive_recent_codes: Vec<String>,
     #[serde(default)]
     receive_output_dir: Option<String>,
+    #[serde(default)]
+    sendme_blob_dir_mode: SendmeBlobDirMode,
+    #[serde(default)]
+    sendme_blob_custom_dir: Option<String>,
     #[serde(default = "default_sendme_one_shot")]
     sendme_one_shot: bool,
     #[serde(default)]
@@ -147,6 +162,8 @@ struct DataBeamApp {
     // Receive
     receive_code: String,
     receive_output_dir: Option<PathBuf>,
+    sendme_blob_dir_mode: SendmeBlobDirMode,
+    sendme_blob_custom_dir: Option<PathBuf>,
 
     // Transfer
     transfer_state: TransferState,
@@ -247,6 +264,8 @@ impl Default for DataBeamApp {
             croc_text_value: String::new(),
             receive_code: String::new(),
             receive_output_dir: None,
+            sendme_blob_dir_mode: SendmeBlobDirMode::SystemTemp,
+            sendme_blob_custom_dir: None,
             transfer_state: TransferState::Idle,
             transfer_progress: 0.0,
             transfer_code: None,
@@ -425,6 +444,12 @@ impl DataBeamApp {
             .as_ref()
             .map(PathBuf::from)
             .filter(|p| !p.as_os_str().is_empty());
+        self.sendme_blob_dir_mode = settings.sendme_blob_dir_mode;
+        self.sendme_blob_custom_dir = settings
+            .sendme_blob_custom_dir
+            .as_ref()
+            .map(PathBuf::from)
+            .filter(|p| !p.as_os_str().is_empty());
         self.sendme_one_shot = settings.sendme_one_shot;
         self.eazysendme_custom_code = settings.eazysendme_custom_code;
         self.eazysendme_auto_retry = true; // Always true on launch
@@ -448,6 +473,11 @@ impl DataBeamApp {
             croc_receive_recent_codes: self.croc_receive_recent_codes.clone(),
             receive_output_dir: self
                 .receive_output_dir
+                .as_ref()
+                .map(|p| p.to_string_lossy().to_string()),
+            sendme_blob_dir_mode: self.sendme_blob_dir_mode,
+            sendme_blob_custom_dir: self
+                .sendme_blob_custom_dir
                 .as_ref()
                 .map(|p| p.to_string_lossy().to_string()),
             sendme_one_shot: self.sendme_one_shot,
@@ -479,7 +509,10 @@ impl DataBeamApp {
             }
         });
         if let Some(ticket) = ticket_to_cleanup {
-            crate::backend::cleanup_sendme_receive_artifacts_for_ticket(&ticket);
+            crate::backend::cleanup_sendme_receive_artifacts_for_ticket(
+                &ticket,
+                self.effective_sendme_blob_dir().as_deref(),
+            );
         }
         self.persist_user_settings();
     }
@@ -500,6 +533,42 @@ impl DataBeamApp {
         self.receive_output_dir
             .clone()
             .or_else(|| std::env::current_dir().ok())
+    }
+
+    fn effective_sendme_blob_dir(&self) -> Option<PathBuf> {
+        match self.sendme_blob_dir_mode {
+            SendmeBlobDirMode::SystemTemp => None,
+            SendmeBlobDirMode::DownloadDir => self.effective_receive_folder(),
+            SendmeBlobDirMode::Custom => self
+                .sendme_blob_custom_dir
+                .clone()
+                .filter(|p| !p.as_os_str().is_empty()),
+        }
+    }
+
+    fn sendme_blob_scan_roots(&self) -> Vec<PathBuf> {
+        let mut roots = vec![std::env::temp_dir()];
+        if let Some(custom) = self.effective_sendme_blob_dir() {
+            if !roots.iter().any(|root| root == &custom) {
+                roots.push(custom);
+            }
+        }
+        roots
+    }
+
+    fn sendme_blob_dir_summary(&self) -> String {
+        match self.sendme_blob_dir_mode {
+            SendmeBlobDirMode::SystemTemp => std::env::temp_dir().to_string_lossy().to_string(),
+            SendmeBlobDirMode::DownloadDir => self
+                .effective_receive_folder()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|| "Same as download folder".to_string()),
+            SendmeBlobDirMode::Custom => self
+                .sendme_blob_custom_dir
+                .as_ref()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|| "Choose a folder".to_string()),
+        }
     }
 
     fn update_derived_speed_from_done_bytes(&mut self) {
@@ -556,6 +625,9 @@ impl DataBeamApp {
                 PickerRequest::ReceiveFolder => {
                     PickerResult::ReceiveFolder(rfd::FileDialog::new().pick_folder())
                 }
+                PickerRequest::SendmeBlobFolder => {
+                    PickerResult::SendmeBlobFolder(rfd::FileDialog::new().pick_folder())
+                }
             };
             let _ = tx.send(result);
         });
@@ -582,9 +654,15 @@ impl DataBeamApp {
                         self.receive_output_dir = Some(path);
                         self.persist_user_settings();
                     }
+                    PickerResult::SendmeBlobFolder(Some(path)) => {
+                        self.sendme_blob_custom_dir = Some(path);
+                        self.sendme_blob_dir_mode = SendmeBlobDirMode::Custom;
+                        self.persist_user_settings();
+                    }
                     PickerResult::SendFolder(None)
                     | PickerResult::SendFiles(None)
-                    | PickerResult::ReceiveFolder(None) => {}
+                    | PickerResult::ReceiveFolder(None)
+                    | PickerResult::SendmeBlobFolder(None) => {}
                 }
             }
             Err(std::sync::mpsc::TryRecvError::Empty) => {
@@ -1671,6 +1749,7 @@ impl DataBeamApp {
                                             let opts = SendmeReceiveOptions {
                                                 ticket: normalized_ticket,
                                                 output_dir: self.receive_output_dir.clone(),
+                                                blob_dir: self.effective_sendme_blob_dir(),
                                                 overwrite: true, // Smart overwrite is now the default
                                             };
                                             let sendme_binary = self.get_tool_binary(&Tool::Sendme).unwrap_or_default();
@@ -1700,7 +1779,10 @@ impl DataBeamApp {
                                             && self.view == AppView::Receive
                                         {
                                             if let Some(ticket) = self.transfer_code.clone() {
-                                                crate::backend::cleanup_sendme_receive_artifacts_for_ticket(&ticket);
+                                                crate::backend::cleanup_sendme_receive_artifacts_for_ticket(
+                                                    &ticket,
+                                                    self.effective_sendme_blob_dir().as_deref(),
+                                                );
                                             }
                                         }
                                          
@@ -1712,9 +1794,12 @@ impl DataBeamApp {
                                              } else {
                                                  // Fallback
                                                  self.eazysendme_code_ticket_map.remove(&code_key);
-                                                 crate::backend::cleanup_sendme_receive_artifacts_for_ticket(&entry.ticket);
+                                                 crate::backend::cleanup_sendme_receive_artifacts_for_ticket(
+                                                     &entry.ticket,
+                                                     self.effective_sendme_blob_dir().as_deref(),
+                                                 );
                                                  self.persist_user_settings();
-                                             }
+                                              }
                                          }
                                     }
                                 }
@@ -2126,6 +2211,7 @@ impl DataBeamApp {
                 let opts = SendmeSendOptions {
                     paths: self.send_paths(),
                     one_shot: self.sendme_one_shot,
+                    blob_dir: self.effective_sendme_blob_dir(),
                 };
                 let (rx, handle) = sendme_send(opts, &binary);
                 self.transfer_rx = Some(rx);
@@ -2153,6 +2239,7 @@ impl DataBeamApp {
                 let opts = SendmeSendOptions {
                     paths: self.send_paths(),
                     one_shot: true,
+                    blob_dir: self.effective_sendme_blob_dir(),
                 };
                 let (rx, handle) = sendme_send(opts, &binary);
                 self.transfer_rx = Some(rx);
@@ -2220,6 +2307,7 @@ impl DataBeamApp {
                 let opts = SendmeReceiveOptions {
                     ticket: self.receive_code.trim().to_string(),
                     output_dir: self.receive_output_dir.clone(),
+                    blob_dir: self.effective_sendme_blob_dir(),
                     overwrite: true, // Smart overwrite for standalone Sendme receive.
                 };
                 let (rx, handle) = sendme_receive(opts, &binary);
@@ -2230,7 +2318,10 @@ impl DataBeamApp {
                 let code_key = self.receive_code.trim().to_string();
 
                 if let Some(entry) = self.eazysendme_code_ticket_map.get(&code_key) {
-                    let disk_size = crate::backend::get_sendme_blob_directory_size(&entry.ticket);
+                    let disk_size = crate::backend::get_sendme_blob_directory_size(
+                        &entry.ticket,
+                        self.effective_sendme_blob_dir().as_deref(),
+                    );
 
                     self.transfer_log.push(if disk_size > 0 {
                         format!(
@@ -2247,6 +2338,7 @@ impl DataBeamApp {
                     let opts = SendmeReceiveOptions {
                         ticket: entry.ticket.clone(),
                         output_dir: self.receive_output_dir.clone(),
+                        blob_dir: self.effective_sendme_blob_dir(),
                         overwrite: true, // Use smart overwrite for local exports too
                     };
                     let (rx, handle) = sendme_check_local(opts);
@@ -2523,11 +2615,11 @@ impl eframe::App for DataBeamApp {
             let (tx, rx) = std::sync::mpsc::channel();
             self.cleanup_scan_rx = Some(rx);
             let map = self.eazysendme_code_ticket_map.clone();
+            let scan_roots = self.sendme_blob_scan_roots();
             std::thread::spawn(move || {
                 let mut targets = Vec::new();
                 let mut total_bytes = 0;
-                let temp_dir = std::env::temp_dir();
-                
+
                 fn dir_size(path: &std::path::Path) -> u64 {
                     let mut total = 0;
                     if let Ok(entries) = std::fs::read_dir(path) {
@@ -2543,29 +2635,35 @@ impl eframe::App for DataBeamApp {
                     }
                     total
                 }
-                
-                if let Ok(entries) = std::fs::read_dir(&temp_dir) {
-                    for entry in entries.flatten() {
-                        let name = entry.file_name().to_string_lossy().to_string();
-                        if name.starts_with(".sendme-recv-") {
-                            let path = entry.path();
-                            if !path.is_dir() { continue; }
-                            
-                            let hex_hash = name.strip_prefix(".sendme-recv-").unwrap_or("");
-                            let mut is_incomplete = true;
-                            for cache in map.values() {
-                                if let Some(h) = native_ticket_to_hex_hash(&cache.ticket) {
-                                    if h == hex_hash {
-                                        is_incomplete = false; // managed cache entry
-                                        break;
+
+                for root in scan_roots {
+                    if let Ok(entries) = std::fs::read_dir(&root) {
+                        for entry in entries.flatten() {
+                            let name = entry.file_name().to_string_lossy().to_string();
+                            if name.starts_with(".sendme-recv-") {
+                                let path = entry.path();
+                                if !path.is_dir() {
+                                    continue;
+                                }
+
+                                let hex_hash = name.strip_prefix(".sendme-recv-").unwrap_or("");
+                                let mut is_incomplete = true;
+                                for cache in map.values() {
+                                    if let Some(h) = native_ticket_to_hex_hash(&cache.ticket) {
+                                        if h == hex_hash {
+                                            is_incomplete = false;
+                                            break;
+                                        }
                                     }
                                 }
-                            }
-                            // Empty temp dirs with size 0 aren't worth bothering the user about
-                            let size = dir_size(&path);
-                            if is_incomplete && size > 1024 * 1024 {
-                                targets.push(path);
-                                total_bytes += size;
+                                let size = dir_size(&path);
+                                if is_incomplete
+                                    && size > 1024 * 1024
+                                    && !targets.iter().any(|existing| existing == &path)
+                                {
+                                    targets.push(path);
+                                    total_bytes += size;
+                                }
                             }
                         }
                     }
@@ -3198,6 +3296,105 @@ impl DataBeamApp {
         });
     }
 
+    fn show_sendme_blob_dir_setup(&mut self, ui: &mut egui::Ui, locked: bool) {
+        if self.selected_tool != SelectedTool::Sendme
+            && self.selected_tool != SelectedTool::EazySendme
+        {
+            return;
+        }
+
+        card_frame(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.label(
+                    RichText::new("Blob Cache")
+                        .color(TEXT_PRIMARY)
+                        .strong()
+                        .size(13.0),
+                );
+                ui.label(
+                    RichText::new(truncate_middle(&self.sendme_blob_dir_summary(), 46))
+                        .color(TEXT_MUTED)
+                        .size(11.0),
+                );
+            });
+            ui.add_space(4.0);
+            ui.add_enabled_ui(!locked, |ui| {
+                let mut changed = false;
+                changed |= ui
+                    .radio_value(
+                        &mut self.sendme_blob_dir_mode,
+                        SendmeBlobDirMode::SystemTemp,
+                        "Use OS temp folder",
+                    )
+                    .changed();
+                changed |= ui
+                    .radio_value(
+                        &mut self.sendme_blob_dir_mode,
+                        SendmeBlobDirMode::DownloadDir,
+                        "Use same folder as downloads",
+                    )
+                    .changed();
+                changed |= ui
+                    .radio_value(
+                        &mut self.sendme_blob_dir_mode,
+                        SendmeBlobDirMode::Custom,
+                        "Use custom folder",
+                    )
+                    .changed();
+
+                if self.sendme_blob_dir_mode == SendmeBlobDirMode::Custom {
+                    ui.add_space(4.0);
+                    ui.horizontal(|ui| {
+                        let custom_text = self
+                            .sendme_blob_custom_dir
+                            .as_ref()
+                            .map(|p| p.to_string_lossy().to_string())
+                            .unwrap_or_else(|| "Choose a folder".to_string());
+                        ui.label(
+                            RichText::new(truncate_middle(&custom_text, 40))
+                                .color(TEXT_MUTED)
+                                .size(10.5),
+                        );
+                        if accent_button_sized(
+                            ui,
+                            "📂",
+                            self.engine_color(),
+                            Vec2::new(32.0, 22.0),
+                        )
+                        .clicked()
+                        {
+                            self.launch_picker(PickerRequest::SendmeBlobFolder);
+                        }
+                        if self.sendme_blob_custom_dir.is_some()
+                            && accent_button_sized(
+                                ui,
+                                "✕",
+                                Color32::from_rgb(130, 85, 85),
+                                Vec2::new(24.0, 22.0),
+                            )
+                            .clicked()
+                        {
+                            self.sendme_blob_custom_dir = None;
+                            self.sendme_blob_dir_mode = SendmeBlobDirMode::SystemTemp;
+                            changed = true;
+                        }
+                    });
+                }
+
+                if changed {
+                    self.persist_user_settings();
+                }
+            });
+            ui.label(
+                RichText::new(
+                    "Used for Sendme and EazySendme temporary blob/cache data on both send and receive.",
+                )
+                .color(TEXT_MUTED)
+                .size(10.0),
+            );
+        });
+    }
+
     fn show_send(&mut self, ui: &mut egui::Ui) {
         section_header(ui, "📤", "Send");
         ui.add_space(4.0);
@@ -3278,6 +3475,13 @@ impl DataBeamApp {
         }
 
         // ── File list ──
+        self.show_sendme_blob_dir_setup(ui, send_locked);
+        if self.selected_tool == SelectedTool::Sendme
+            || self.selected_tool == SelectedTool::EazySendme
+        {
+            ui.add_space(6.0);
+        }
+
         card_frame(ui, |ui| {
             ui.horizontal(|ui| {
                 ui.label(
@@ -3639,7 +3843,10 @@ impl DataBeamApp {
                     };
 
                     if let Some(tick) = ticket_to_check {
-                        let disk_size = crate::backend::get_sendme_blob_directory_size(&tick);
+                        let disk_size = crate::backend::get_sendme_blob_directory_size(
+                            &tick,
+                            self.effective_sendme_blob_dir().as_deref(),
+                        );
                         if disk_size > 0 {
                             (
                                 true,
@@ -3731,6 +3938,15 @@ impl DataBeamApp {
                 });
             });
         });
+        self.show_sendme_blob_dir_setup(
+            ui,
+            self.transfer_state == TransferState::Running,
+        );
+        if self.selected_tool == SelectedTool::Sendme
+            || self.selected_tool == SelectedTool::EazySendme
+        {
+            ui.add_space(6.0);
+        }
         if self.selected_tool == SelectedTool::Croc {
             let text = self
                 .croc_received_text

--- a/third_party/sendme/src/core/receive.rs
+++ b/third_party/sendme/src/core/receive.rs
@@ -699,27 +699,6 @@ pub async fn check_and_export_local_in(
 
     Ok(true)
 }
-/// Checks if a specific ticket exists as a local blob directory in temp_dir.
-pub fn local_ticket_exists_on_disk(ticket_str: &str) -> bool {
-    local_ticket_exists_on_disk_in(ticket_str, None)
-}
-
-pub fn local_ticket_exists_on_disk_in(ticket_str: &str, blob_dir: Option<PathBuf>) -> bool {
-    let Ok(ticket) = BlobTicket::from_str(ticket_str) else {
-        return false;
-    };
-    let expected_dir = format!(".sendme-recv-{}", ticket.hash().to_hex());
-    let mut candidates = Vec::new();
-    if let Some(base) = blob_dir {
-        candidates.push(base.join(&expected_dir));
-    }
-    let temp_candidate = std::env::temp_dir().join(expected_dir);
-    if !candidates.contains(&temp_candidate) {
-        candidates.push(temp_candidate);
-    }
-    candidates.into_iter().any(|path| path.exists())
-}
-
 /// Recursively calculates the size of a directory.
 fn calculate_dir_size(path: &std::path::Path) -> u64 {
     let mut total = 0;

--- a/third_party/sendme/src/core/receive.rs
+++ b/third_party/sendme/src/core/receive.rs
@@ -529,11 +529,27 @@ pub async fn check_and_export_local(
 }
 
 pub fn cleanup_sendme_receive_artifacts_for_ticket(ticket_str: &str) {
+    cleanup_sendme_receive_artifacts_for_ticket_in(ticket_str, None)
+}
+
+pub fn cleanup_sendme_receive_artifacts_for_ticket_in(
+    ticket_str: &str,
+    blob_dir: Option<PathBuf>,
+) {
     if let Ok(ticket) = BlobTicket::from_str(ticket_str) {
         let dir_name = format!(".sendme-recv-{}", ticket.hash().to_hex());
+        let mut candidates = Vec::new();
+        if let Some(base) = blob_dir {
+            candidates.push(base.join(&dir_name));
+        }
         let temp_candidate = std::env::temp_dir().join(&dir_name);
-        if temp_candidate.exists() {
-            let _ = std::fs::remove_dir_all(temp_candidate);
+        if !candidates.contains(&temp_candidate) {
+            candidates.push(temp_candidate);
+        }
+        for candidate in candidates {
+            if candidate.exists() {
+                let _ = std::fs::remove_dir_all(candidate);
+            }
         }
     }
 }
@@ -668,19 +684,40 @@ pub async fn check_and_export_local_in(
     // Clean up the temporary blob store after successful local export
     if let Ok(ticket) = BlobTicket::from_str(ticket_str) {
         let expected_dir = format!(".sendme-recv-{}", ticket.hash().to_hex());
-        let iroh_data_dir = std::env::temp_dir().join(expected_dir);
-        let _ = tokio::fs::remove_dir_all(&iroh_data_dir).await;
+        let mut cleanup_targets = Vec::new();
+        cleanup_targets.push(std::env::temp_dir().join(&expected_dir));
+        if let Some(base) = blob_dir {
+            let custom_target = base.join(&expected_dir);
+            if !cleanup_targets.contains(&custom_target) {
+                cleanup_targets.push(custom_target);
+            }
+        }
+        for iroh_data_dir in cleanup_targets {
+            let _ = tokio::fs::remove_dir_all(&iroh_data_dir).await;
+        }
     }
 
     Ok(true)
 }
 /// Checks if a specific ticket exists as a local blob directory in temp_dir.
 pub fn local_ticket_exists_on_disk(ticket_str: &str) -> bool {
+    local_ticket_exists_on_disk_in(ticket_str, None)
+}
+
+pub fn local_ticket_exists_on_disk_in(ticket_str: &str, blob_dir: Option<PathBuf>) -> bool {
     let Ok(ticket) = BlobTicket::from_str(ticket_str) else {
         return false;
     };
     let expected_dir = format!(".sendme-recv-{}", ticket.hash().to_hex());
-    std::env::temp_dir().join(expected_dir).exists()
+    let mut candidates = Vec::new();
+    if let Some(base) = blob_dir {
+        candidates.push(base.join(&expected_dir));
+    }
+    let temp_candidate = std::env::temp_dir().join(expected_dir);
+    if !candidates.contains(&temp_candidate) {
+        candidates.push(temp_candidate);
+    }
+    candidates.into_iter().any(|path| path.exists())
 }
 
 /// Recursively calculates the size of a directory.
@@ -703,15 +740,28 @@ fn calculate_dir_size(path: &std::path::Path) -> u64 {
 
 /// Returns the total size in bytes of the local blob directory for the given ticket.
 pub fn local_ticket_size_on_disk(ticket_str: &str) -> u64 {
+    local_ticket_size_on_disk_in(ticket_str, None)
+}
+
+pub fn local_ticket_size_on_disk_in(ticket_str: &str, blob_dir: Option<PathBuf>) -> u64 {
     let Ok(ticket) = BlobTicket::from_str(ticket_str) else {
         return 0;
     };
     let expected_dir = format!(".sendme-recv-{}", ticket.hash().to_hex());
-    let path = std::env::temp_dir().join(expected_dir);
-    if !path.exists() {
-        return 0;
+    let mut candidates = Vec::new();
+    if let Some(base) = blob_dir {
+        candidates.push(base.join(&expected_dir));
     }
-    calculate_dir_size(&path)
+    let temp_candidate = std::env::temp_dir().join(expected_dir);
+    if !candidates.contains(&temp_candidate) {
+        candidates.push(temp_candidate);
+    }
+    candidates
+        .into_iter()
+        .filter(|path| path.exists())
+        .map(|path| calculate_dir_size(&path))
+        .max()
+        .unwrap_or(0)
 }
 
 #[cfg(test)]

--- a/third_party/sendme/src/core/send.rs
+++ b/third_party/sendme/src/core/send.rs
@@ -127,7 +127,11 @@ pub async fn start_share(
     }
 
     let suffix = rand::rng().random::<[u8; 16]>();
-    let temp_base = std::env::temp_dir();
+    let temp_base = {
+        let base = options.blob_dir.clone().unwrap_or_else(std::env::temp_dir);
+        let _ = std::fs::create_dir_all(&base);
+        base
+    };
     let blobs_data_dir = temp_base.join(format!(".sendme-send-{}", HEXLOWER.encode(&suffix)));
     if blobs_data_dir.exists() {
         anyhow::bail!(

--- a/third_party/sendme/src/core/send.rs
+++ b/third_party/sendme/src/core/send.rs
@@ -103,7 +103,8 @@ fn emit_event_with_payload<T: Serialize>(app_handle: &AppHandle, event_name: &st
     }
 }
 pub async fn start_share(
-    path: PathBuf,
+    paths: Vec<PathBuf>,
+    payload_root: String,
     options: SendOptions,
     app_handle: AppHandle,
 ) -> anyhow::Result<SendResult> {
@@ -139,17 +140,18 @@ pub async fn start_share(
             temp_base.display(),
         );
     }
-    let cwd = std::env::current_dir()?;
-    if cwd.join(&path) == cwd {
-        anyhow::bail!("can not share from the current directory");
-    }
-
-    let path2 = path.clone();
     let blobs_data_dir2 = blobs_data_dir.clone();
     let (progress_tx, progress_rx) = mpsc::channel(32);
     let app_handle_clone = app_handle.clone();
-    let entry_type = if path.is_file() { "file" } else { "directory" };
+    anyhow::ensure!(!paths.is_empty(), "no valid paths to share");
+    let entry_type = if paths.len() == 1 && paths[0].is_file() {
+        "file"
+    } else {
+        "directory"
+    };
     let entry_type_for_progress = entry_type.to_string();
+    let paths2 = paths.clone();
+    let payload_root2 = payload_root.clone();
 
     let setup = async move {
         let t0 = Instant::now();
@@ -171,7 +173,7 @@ pub async fn start_share(
             )),
         );
 
-        let import_result = import(path2, blobs.store()).await?;
+        let import_result = import(paths2, payload_root2, blobs.store()).await?;
         let dt = t0.elapsed();
 
         let (ref _temp_tag, size, ref _collection) = import_result;
@@ -239,43 +241,15 @@ pub async fn start_share(
     })
 }
 
-async fn import(path: PathBuf, db: &Store) -> anyhow::Result<(TempTag, u64, Collection)> {
-    let parallelism = num_cpus::get();
-    let path = path.canonicalize()?;
-    anyhow::ensure!(path.exists(), "path {} does not exist", path.display());
-    let root = path.parent().context("context get parent")?;
-    let files = WalkDir::new(path.clone()).into_iter();
-    let data_sources: Vec<(String, PathBuf)> = files
-        .filter_map(|entry| {
-            let entry = match entry {
-                Ok(e) => e,
-                Err(e) => {
-                    tracing::warn!("skipping inaccessible entry: {}", e);
-                    return None;
-                }
-            };
-            if !entry.file_type().is_file() {
-                return None;
-            }
-            let path = entry.into_path();
-            let relative = match path.strip_prefix(root) {
-                Ok(r) => r,
-                Err(e) => {
-                    tracing::warn!("skipping {}: {}", path.display(), e);
-                    return None;
-                }
-            };
-            match canonicalized_path_to_string(relative, true) {
-                Ok(name) => Some((name, path)),
-                Err(e) => {
-                    tracing::warn!("skipping {}: {}", path.display(), e);
-                    None
-                }
-            }
-        })
-        .collect();
-
+async fn import(
+    paths: Vec<PathBuf>,
+    payload_root: String,
+    db: &Store,
+) -> anyhow::Result<(TempTag, u64, Collection)> {
+    let data_sources = build_virtual_data_sources(paths, &payload_root)?;
     anyhow::ensure!(!data_sources.is_empty(), "no valid files to share");
+
+    let parallelism = num_cpus::get();
 
     let mut names_and_tags = n0_future::stream::iter(data_sources)
         .map(|(name, path)| {
@@ -327,6 +301,63 @@ async fn import(path: PathBuf, db: &Store) -> anyhow::Result<(TempTag, u64, Coll
     let temp_tag = collection.clone().store(db).await?;
     drop(tags);
     Ok((temp_tag, size, collection))
+}
+
+fn build_virtual_data_sources(
+    paths: Vec<PathBuf>,
+    payload_root: &str,
+) -> anyhow::Result<Vec<(String, PathBuf)>> {
+    let mut data_sources = Vec::new();
+
+    for source in paths {
+        let canonical = source.canonicalize()?;
+        anyhow::ensure!(
+            canonical.exists(),
+            "path {} does not exist",
+            canonical.display()
+        );
+
+        let source_name = canonical
+            .file_name()
+            .context("shared path has no file name")?;
+        let source_name = canonicalized_path_to_string(Path::new(source_name), true)?;
+
+        if canonical.is_file() {
+            data_sources.push((format!("{payload_root}/{source_name}"), canonical));
+            continue;
+        }
+
+        for entry in WalkDir::new(&canonical).into_iter() {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::warn!("skipping inaccessible entry: {}", e);
+                    continue;
+                }
+            };
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            let path = entry.into_path();
+            let relative = match path.strip_prefix(&canonical) {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!("skipping {}: {}", path.display(), e);
+                    continue;
+                }
+            };
+            let relative = match canonicalized_path_to_string(relative, true) {
+                Ok(name) => name,
+                Err(e) => {
+                    tracing::warn!("skipping {}: {}", path.display(), e);
+                    continue;
+                }
+            };
+            data_sources.push((format!("{payload_root}/{source_name}/{relative}"), path));
+        }
+    }
+
+    Ok(data_sources)
 }
 
 pub fn canonicalized_path_to_string(

--- a/third_party/sendme/src/core/types.rs
+++ b/third_party/sendme/src/core/types.rs
@@ -36,6 +36,8 @@ pub struct SendOptions {
     pub ticket_type: AddrInfoOptions,
     pub magic_ipv4_addr: Option<std::net::SocketAddrV4>,
     pub magic_ipv6_addr: Option<std::net::SocketAddrV6>,
+    /// If set, iroh blob stores are created under this directory instead of std::env::temp_dir().
+    pub blob_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Default)]

--- a/third_party/sendme/src/lib.rs
+++ b/third_party/sendme/src/lib.rs
@@ -3,8 +3,7 @@ pub mod core;
 pub use core::{
     receive::{
         check_and_export_local, check_and_export_local_in, download,
-        local_ticket_exists_on_disk, local_ticket_exists_on_disk_in, local_ticket_size_on_disk,
-        local_ticket_size_on_disk_in, cleanup_sendme_receive_artifacts_for_ticket,
+        local_ticket_size_on_disk, local_ticket_size_on_disk_in, cleanup_sendme_receive_artifacts_for_ticket,
         cleanup_sendme_receive_artifacts_for_ticket_in, ticket_to_hex_hash,
     },
     send::start_share,

--- a/third_party/sendme/src/lib.rs
+++ b/third_party/sendme/src/lib.rs
@@ -3,8 +3,9 @@ pub mod core;
 pub use core::{
     receive::{
         check_and_export_local, check_and_export_local_in, download,
-        local_ticket_exists_on_disk, local_ticket_size_on_disk,
-        cleanup_sendme_receive_artifacts_for_ticket, ticket_to_hex_hash,
+        local_ticket_exists_on_disk, local_ticket_exists_on_disk_in, local_ticket_size_on_disk,
+        local_ticket_size_on_disk_in, cleanup_sendme_receive_artifacts_for_ticket,
+        cleanup_sendme_receive_artifacts_for_ticket_in, ticket_to_hex_hash,
     },
     send::start_share,
     types::{

--- a/trubleshoot.md
+++ b/trubleshoot.md
@@ -8,6 +8,7 @@
 
 ## Common UI Issues
 - If app width is small , UI persentation may not be desirable. In that case , please resize the app window.
+- progress bar/status is broken, acts funky if retry during export. But don't worry the core functionality is not disrupted. Just an UI issue.
 
 ## Suggestions
 - Use Standalone Sendme mode for sensitive data transfers.


### PR DESCRIPTION
## Summary
Optimized sender I/O by replacing making staging dir with virtual manifest

## Validation

- [ pass] `cargo check`
- [ pass] `cargo test`
- [success ] Manual send/receive smoke test (if transfer behavior changed)

## Release Notes

- User-facing impact:
Significant reduction in sender preparing phase time. Reduced wait times.

- Breaking changes:
In croc mode removed staging dir. Now works similar to croc cli.